### PR TITLE
Added support for search_read and fields_get methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,20 @@ Odoo.prototype.search = function (model, params, callback) {
   }, callback);
 };
 
+// Search_read records
+Odoo.prototype.search_read = function (model, {domain= [], fields= [], limit= 0, offset= 0, sort= ''}, callback) {
+  if (!fields.length) return console.error("The search_read method doesn't support an empty fields array.");
+  this._request('/web/dataset/search_read', {
+    context: this.context,
+    model,
+    domain,
+    fields,
+    limit,
+    offset,
+    sort,
+  }, callback);
+};
+
 // Private functions
 Odoo.prototype._request = function (path, params, callback) {
   params = params || {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,18 @@ Odoo.prototype.search_read = function (model, {domain= [], fields= [], limit= 0,
   }, callback);
 };
 
+// Added fields_get method
+Odoo.prototype.fields_get = function (model, {fields= [], attributes= {}}, callback) {
+  this._request('/web/dataset/call_kw', {
+    kwargs: {
+      context: this.context
+    },
+    model,
+    method: 'fields_get',
+    args: [fields, attributes],
+  }, callback);
+};
+
 // Private functions
 Odoo.prototype._request = function (path, params, callback) {
   params = params || {};


### PR DESCRIPTION
This pull request adds support for:
- [fields_get](https://www.odoo.com/documentation/11.0/webservices/odoo.html#listing-record-fields)
- [search_read](https://www.odoo.com/documentation/11.0/webservices/odoo.html#listing-record-fields): The fields array **must contain at least one fields** for the request to be successfull, as opposed to what's mentioned currently in the docs (excerpt: Its arguments are similar to search()’s, but it can also take a list of fields (like read(), if that list is not provided it will fetch all fields of matched records))
